### PR TITLE
Remove babel-plugin-transform-es2015-block-scoping dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "coveralls": "npm run coverage -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "devDependencies": {
-    "babel-plugin-transform-es2015-block-scoping": "^6.26.0",
     "chai": "^4.1.2",
     "istanbul": "^0.4.5",
     "jscs": "^3.0.7",


### PR DESCRIPTION
Fixed since https://github.com/jhnns/rewire/blob/master/CHANGELOG.md#301